### PR TITLE
Add executive sorting to the member list

### DIFF
--- a/_data/roles.json
+++ b/_data/roles.json
@@ -1,0 +1,29 @@
+{
+  "0": {
+    "title": "Advisor"
+  },
+  "1": {
+    "title": "President"
+  },
+  "2": {
+    "title": "Vice President"
+  },
+  "3": {
+    "title": "ICC Representative"
+  },
+  "4": {
+    "title": "Secretary"
+  },
+  "5": {
+    "title": "Treasurer"
+  },
+  "6": {
+    "title": "Project Manager"
+  },
+  "7": {
+    "title": "Event Coordinator"
+  },
+  "8": {
+    "title": "Social Media Manager"
+  }
+}

--- a/_includes/member_table.html
+++ b/_includes/member_table.html
@@ -6,6 +6,13 @@
         <h3 style="margin:0">{{ member.name }}</h3>
         <p>{{member.short_bio}}</p>
         <span>
+          {% if member.role %}
+            {% capture role %}{{ member.role }}{% endcapture %}
+            {% assign title = site.data.roles[role].title %}
+            <p><img class="icon" src="/assets/logo.png">{{ title }}</p>
+          {% endif %}
+        </span>
+        <span>
           {% if member.website %}
             <img class="icon" src="/assets/link-variant.png"><a href="{{ member.website }}">{{ member.website }}</a>
           {% endif %}

--- a/_members/Christa_Hatch.md
+++ b/_members/Christa_Hatch.md
@@ -2,6 +2,7 @@
 name: Christa Hatch
 short_bio: Computer science major with an interest in video games and cosplay. Currently the ICC representative for the Computer Science Club.
 image_url: https://scontent.fsan1-1.fna.fbcdn.net/v/t1.0-9/29541052_1657894044265604_1307692817870125435_n.jpg?_nc_cat=110&oh=de1ff27a09a93efc0eaf6834437fb090&oe=5C180F2E
+role: 3
 website: https://www.linkedin.com/in/christa-hatch-61231914a
 github: ChristaKH
 discord: ChristaKH#5684

--- a/_members/evan_stewart.md
+++ b/_members/evan_stewart.md
@@ -2,6 +2,7 @@
 name: Evan Stewart
 short_bio: CS student at Miracosta, enjoys ironic situations
 image_url: https://avatars0.githubusercontent.com/u/37439001?s=460&v=4
+role: 1
 github: ekstewart
 discord: 🎃👻 Evan 👻🎃#2486
 ---

--- a/_members/michael_flaherty.md
+++ b/_members/michael_flaherty.md
@@ -2,6 +2,7 @@
 name: Michael Flaherty
 short_bio: Software developer & open-source junkie
 image_url: https://avatars0.githubusercontent.com/u/11095737?s=460&v=4
+role: 6
 website: https://michaelwflaherty.com
 github: Headline
 discord: Headline#9999

--- a/members.html
+++ b/members.html
@@ -9,7 +9,8 @@ order: 4
 <div class="members">
     <h1>{{ site.members.size }} {% if site.members.size == 1 %}Member{% elsif site.members.size != 1 %}Members{% endif %}</h1>
     <table>
-    {% for member in site.members %}
+    {% assign sorted_members = site.members | sort: 'role', 'last' %}
+    {% for member in sorted_members %}
         {% include member_table.html %}
     {% endfor %}
     </table>


### PR DESCRIPTION
# Executives in the member list
The website member list will now display the club executive roles below a members bio's using a new optional `role` attribute in their markdown (`*.md`) file. This PR implements the behavior outlined in #35.

# Visuals
![role](https://i.imgur.com/v5WuEyV.png)

----

![example](https://i.imgur.com/m2CABwj.png)

Live example: [https://christopherwmm.github.io/](https://christopherwmm.github.io/)

# Technical

----

```yml
---
name: Christopher Martin
short_bio: Full-time Computer Science student and budding Computer Science educator. 😁
image_url: https://avatars0.githubusercontent.com/u/9260792?s=460&v=4
role: 1
website: https://christopherwmm.github.io/
github: ChristopherWMM
discord: ChristopherWMM#0458
---
```

\* Due to certain restrictions with the technology, roles must be defined as an integer key which maps a member to their respective role. 

Additionally, the member list will be pre-sorted to ensure that the officers are always displayed first with the following precedence: 
> (0) -> Advisor
> (1) -> President
> (2) -> Vice-President
> (3) -> ICC Representative
> (4) -> Secretary
> (5) -> Treasurer
> (6) -> Project Manager
> (7) -> Event Coordinator
> (8) -> Social Media Manager
> All other members are sorted using lexiographic order by first name.
